### PR TITLE
fix: CF email-obfuscation で破損した issue-labeler templates を修復

### DIFF
--- a/templates/.github/advanced-issue-labeler.yml
+++ b/templates/.github/advanced-issue-labeler.yml
@@ -1,5 +1,5 @@
 # Maps Issue Forms dropdown selections to labels.
-# See https://github.com/stefanbuck/advanced-issue-labeler for syntax.
+# See https://github.com/redhat-plumbers-in-action/advanced-issue-labeler for syntax.
 #
 # Per-repo extension: target repos can append additional `policy` entries
 # (e.g. for area:* labels) by editing this file directly. The shared base
@@ -9,12 +9,12 @@ policy:
       - bug.yml
       - feature.yml
     section:
-      - id: priority
-        block-list:
-          - high
-          - medium
-          - low
+      - id: [priority]
+        block-list: []
         label:
-          - priority:high
-          - priority:medium
-          - priority:low
+          - name: 'priority:high'
+            keys: ['high']
+          - name: 'priority:medium'
+            keys: ['medium']
+          - name: 'priority:low'
+            keys: ['low']

--- a/templates/.github/workflows/label-from-issue.yml
+++ b/templates/.github/workflows/label-from-issue.yml
@@ -13,16 +13,36 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - name: Apply priority labels
-        uses: stefanbuck/[email protected]
+      - uses: actions/checkout@v4
+
+      - name: Parse bug.yml
+        id: parse-bug
+        uses: stefanbuck/github-issue-parser@v3
         with:
+          template-path: .github/ISSUE_TEMPLATE/bug.yml
+        continue-on-error: true
+
+      - name: Apply labels for bug
+        if: steps.parse-bug.outcome == 'success'
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
+        with:
+          issue-form: ${{ steps.parse-bug.outputs.jsonString }}
           template: bug.yml
           section: priority
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Apply priority labels (feature)
-        uses: stefanbuck/[email protected]
+      - name: Parse feature.yml
+        id: parse-feature
+        uses: stefanbuck/github-issue-parser@v3
         with:
+          template-path: .github/ISSUE_TEMPLATE/feature.yml
+        continue-on-error: true
+
+      - name: Apply labels for feature
+        if: steps.parse-feature.outcome == 'success'
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
+        with:
+          issue-form: ${{ steps.parse-feature.outputs.jsonString }}
           template: feature.yml
           section: priority
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

- Workflow `templates/.github/workflows/label-from-issue.yml` の `uses:` に Cloudflare の email-obfuscation placeholder (`[email protected]`) が混入し、GitHub Actions が parse 段階で reject されていた問題を修正
- 公式 README に沿った 2-step pattern (`stefanbuck/github-issue-parser@v3` → `redhat-plumbers-in-action/advanced-issue-labeler@v2`) に書き換え、bug.yml / feature.yml の両 template に対応
- 同一 harvest 由来で `templates/.github/advanced-issue-labeler.yml` の policy schema も破損していたため一括修正:
  - `block-list: [high, medium, low]` → `[]`（旧設定では全 valid 値が除外され、いかなる label も付かない状態だった）
  - `label: [string]` → `[{name, keys}]` の object 配列（README schema 準拠）
  - 先頭コメントの誤URL `stefanbuck/advanced-issue-labeler` → `redhat-plumbers-in-action/advanced-issue-labeler`

## 背景

下流 (`thkt/scout` ほか deploy 済み repo) で push 毎に 0s failure が積み上がっていた (例: thkt/scout#69)。Research レポートでバイトレベルまで原因確認: `5b 65 6d 61 69 6c 20 70 72 6f 74 65 63 74 65 64 5d` = `[email protected]`。HTML harvest 起源の単純破損。

## テスト計画

- [x] `actionlint 1.7.12 templates/.github/workflows/label-from-issue.yml` が exit 0 で通ることを確認
- [ ] merge 後、template-deploy で対象 repo に再 sync する（既存の `add-issue-forms-base` ブランチ衝突に注意。既 deploy 済みの scout は手動同期 PR を別途出す予定）
- [ ] scout 側 PR merge 後に新規 issue (bug.yml / feature.yml) を立てて priority:* label が付与されることを確認

## 関連

- thkt/scout#69
- ADR-0059 (shared template governance)